### PR TITLE
ASイベントのタイトル変更と仮締切設定

### DIFF
--- a/config/events.json
+++ b/config/events.json
@@ -1,8 +1,8 @@
 {
 	"as": {
 		"id": "as",
-		"title": "アークナイツ攻略動画企画応募フォーム",
-		"deadline": null,
+		"title": "イベント『アークナイツ攻略動画企画応募フォーム』攻略動画募集",
+		"deadline": "7/22（火）23時〆切",
 		"thumbnailUrl": "/events/as/as-s-4.jpeg",
 		"stages": [
 			{ "value": "as-ex-8", "label": "AS-EX-8" },


### PR DESCRIPTION
## 概要

イベント名のリネームと仮締切の設定を実施しました。

## 変更内容

- ASイベントのタイトルを「アークナイツ攻略動画企画応募フォーム」から「イベント『アークナイツ攻略動画企画応募フォーム』攻略動画募集」に変更
- 仮締切を7/22（火）２３時〆切に設定

## 変更ファイル

- `config/events.json`

## 確認事項

- イベントタイトルの表示が正しく更新されていること
- 締切情報が適切に表示されていること

❎ 回答者: イシュー #10

🤖 Generated with [Claude Code](https://claude.ai/code)