### PR TITLE
イベント『落日の向こうへ』の締切を4月30日（水）に設定

### DIFF
--- a/config/events.json
+++ b/config/events.json
@@ -43,7 +43,7 @@
 	"go": {
 		"id": "go",
 		"title": "イベント『落日の向こうへ』攻略動画募集",
-		"deadline": null,
+		"deadline": "4/30（水）23時〆切",
 		"thumbnailUrl": "/events/go/go-ex-8.jpg",
 		"stages": [
 			{ "value": "go-ex-8", "label": "GO-EX-8" }


### PR DESCRIPTION
イベント『落日の向こうへ』の締切を4月30日（水）に設定しました。

変更内容:
- `/config/events.json` の `"go"` イベントの締切を更新
- `"deadline": null,` → `"deadline": "4/30（水） 23時〆切",`

Closes #12

Generated with [Claude Code](https://claude.ai/code)