### PR TITLE
fix: トップページのカードのホバー時カーソルを修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,8 +75,7 @@ export default function HomePage() {
 					{events.map((event) => (
 						<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
 							<Card
-								hoverable
-								className="h-full [&_.ant-card-body]:px-4 [&_.ant-card-body]:py-4"
+								className="h-full [&_.ant-card-body]:px-4 [&_.ant-card-body]:py-4 transition-shadow hover:shadow-lg cursor-default"
 								cover={
 									<div className="relative aspect-video bg-gray-100">
 										<Image


### PR DESCRIPTION
## 概要
トップページのイベントカードにマウスオーバーした際のカーソル表示を修正しました。

## 変更内容
- Cardコンポーネントの`hoverable`属性を削除
- `cursor-default`を追加し、カード全体ではマウスカーソルがデフォルト（矢印）のまま
- 「応募ページへ」ボタンのみで指の形のカーソルが表示される
- ホバー時の視覚効果は`hover:shadow-lg`で維持

## 動作確認
- [x] トップページでカードにマウスオーバーしてもカーソルが指の形にならないことを確認
- [x] 「応募ページへ」ボタンにマウスオーバーすると指の形になることを確認
- [x] カードのホバー時にシャドウエフェクトが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)