### PR TITLE
feat: イベントを現在進行中と過去に分類して表示

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,8 +47,24 @@ function parseDeadline(deadline: string | null): number {
 	return month * 100 + day;
 }
 
+// 現在日付を取得して比較用の値を返す関数
+function getCurrentDate(): number {
+	const now = new Date();
+	const month = now.getMonth() + 1; // 0から始まるため+1
+	const day = now.getDate();
+	return month * 100 + day;
+}
+
+// 締切日が現在日付より後かどうかを判定する関数
+function isEventActive(deadline: string | null): boolean {
+	if (!deadline) return false;
+	const currentDate = getCurrentDate();
+	const deadlineDate = parseDeadline(deadline);
+	return deadlineDate >= currentDate;
+}
+
 // config/events.json から動的にイベントデータを生成
-const events: Event[] = Object.values(
+const allEvents: Event[] = Object.values(
 	eventsConfig as Record<string, EventConfig>,
 )
 	.filter((event) => event.active)
@@ -63,6 +79,57 @@ const events: Event[] = Object.values(
 		// 締切日の降順でソート（最新の締切日が最初）
 		return parseDeadline(b.deadline) - parseDeadline(a.deadline);
 	});
+
+// 現在進行中のイベントと過去のイベントに分類
+const activeEvents = allEvents.filter((event) => isEventActive(event.deadline));
+const pastEvents = allEvents.filter((event) => !isEventActive(event.deadline));
+
+// イベントカードを表示するコンポーネント
+function EventCard({ event, isPast = false }: { event: Event; isPast?: boolean }) {
+	return (
+		<Card
+			className={`h-full [&_.ant-card-body]:px-4 [&_.ant-card-body]:py-4 transition-shadow hover:shadow-lg cursor-default ${
+				isPast ? "opacity-80" : ""
+			}`}
+			cover={
+				<div className="relative aspect-video bg-gray-100">
+					<Image
+						src={event.thumbnail}
+						alt={event.title}
+						fill
+						className="object-cover"
+						sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
+					/>
+				</div>
+			}
+			actions={[
+				<div key="apply" className="mx-4">
+					<Link href={event.path}>
+						<Button type={isPast ? "default" : "primary"} block>
+							{isPast ? "詳細を見る" : "応募ページへ"}
+						</Button>
+					</Link>
+				</div>,
+			]}
+		>
+			<div className="space-y-2">
+				<div className="text-base font-medium leading-relaxed line-clamp-2 min-h-[3rem]">
+					{event.title}
+				</div>
+				<div className="min-h-[2rem] flex items-center">
+					{event.hasDeadline && (
+						<div className="flex items-center gap-1">
+							<CalendarOutlined className={isPast ? "text-gray-400" : "text-red-500"} />
+							<Tag color={isPast ? "default" : "red"} className="text-sm">
+								{event.deadline}
+							</Tag>
+						</div>
+					)}
+				</div>
+			</div>
+		</Card>
+	);
+}
 
 export default function HomePage() {
 	return (
@@ -86,55 +153,51 @@ export default function HomePage() {
 						アークナイツ攻略動画同時視聴企画
 					</Title>
 					<Text type="secondary" className="text-lg">
-						過去に募集したイベントの一覧です
+						イベントの投稿企画一覧
 					</Text>
 				</div>
 
-				<Row gutter={[24, 24]} justify="center">
-					{events.map((event) => (
-						<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
-							<Card
-								className="h-full [&_.ant-card-body]:px-4 [&_.ant-card-body]:py-4 transition-shadow hover:shadow-lg cursor-default"
-								cover={
-									<div className="relative aspect-video bg-gray-100">
-										<Image
-											src={event.thumbnail}
-											alt={event.title}
-											fill
-											className="object-cover"
-											sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
-										/>
-									</div>
-								}
-								actions={[
-									<div key="apply" className="mx-4">
-										<Link href={event.path}>
-											<Button type="primary" block>
-												応募ページへ
-											</Button>
-										</Link>
-									</div>,
-								]}
-							>
-								<div className="space-y-2">
-									<div className="text-base font-medium leading-relaxed line-clamp-2 min-h-[3rem]">
-										{event.title}
-									</div>
-									<div className="min-h-[2rem] flex items-center">
-										{event.hasDeadline && (
-											<div className="flex items-center gap-1">
-												<CalendarOutlined className="text-red-500" />
-												<Tag color="red" className="text-sm">
-													{event.deadline}
-												</Tag>
-											</div>
-										)}
-									</div>
-								</div>
-							</Card>
-						</Col>
-					))}
-				</Row>
+				{/* 現在進行中のイベント */}
+				{activeEvents.length > 0 && (
+					<div className="mb-16">
+						<div className="text-center mb-8">
+							<Title level={2} className="!mb-2">
+								🔥 現在進行中のイベント
+							</Title>
+							<Text type="secondary">
+								現在応募可能なイベントです
+							</Text>
+						</div>
+						<Row gutter={[24, 24]} justify="center">
+							{activeEvents.map((event) => (
+								<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
+									<EventCard event={event} />
+								</Col>
+							))}
+						</Row>
+					</div>
+				)}
+
+				{/* 過去のイベント */}
+				{pastEvents.length > 0 && (
+					<div className="mb-16">
+						<div className="text-center mb-8">
+							<Title level={2} className="!mb-2">
+								📚 過去のイベント
+							</Title>
+							<Text type="secondary">
+								過去に募集したイベントの一覧です
+							</Text>
+						</div>
+						<Row gutter={[24, 24]} justify="center">
+							{pastEvents.map((event) => (
+								<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
+									<EventCard event={event} isPast={true} />
+								</Col>
+							))}
+						</Row>
+					</div>
+				)}
 
 				<div className="text-center mt-12">
 					<Text type="secondary">


### PR DESCRIPTION
## 概要
トップページのイベント一覧を、現在日付と締切日を比較して現在進行中のイベントと過去のイベントに分類して表示するように改善しました。

## 主な変更内容

### 1. イベント分類機能の追加
- `getCurrentDate()` 関数で現在の日付を取得
- `isEventActive()` 関数で締切日が現在日付以降かを判定
- イベントを現在進行中（activeEvents）と過去（pastEvents）に分類

### 2. UI の大幅改善
- **現在進行中のイベント**：
  - 🔥 アイコンとセクション
  - 「応募ページへ」ボタン（青色）
  - 赤いカレンダーアイコンと締切日タグ
  
- **過去のイベント**：
  - 📚 アイコンとセクション
  - 「詳細を見る」ボタン（グレー）
  - グレーのカレンダーアイコンと締切日タグ
  - カード全体に透明度80%を適用

### 3. コンポーネントの抽出
- `EventCard` コンポーネントを抽出
- `isPast` プロップでスタイルを切り替え可能に

### 4. レイアウト改善
- 現在進行中のイベントを最上部に配置
- 過去のイベントをその下に配置
- 各セクションに明確なタイトルと説明文を追加

## 動作確認
- [x] 現在日付（7/17）と締切日を比較してイベントが正しく分類されることを確認
- [x] 現在進行中のイベント（8/7、7/31）が最上部に表示されることを確認
- [x] 過去のイベント（6/19以前）が「過去のイベント」セクションに表示されることを確認
- [x] 各セクションのスタイルが適切に適用されることを確認

## 技術的な詳細
- 日付比較は「月 * 100 + 日」形式で行い、簡潔で効率的
- 現在進行中のイベントが存在しない場合はセクション自体を非表示
- 過去のイベントが存在しない場合はセクション自体を非表示
- レスポンシブデザインを維持

🤖 Generated with [Claude Code](https://claude.ai/code)