### PR TITLE
feat: 過去のイベント用の動画一覧ページを追加とアクセス制御

### DIFF
--- a/src/app/[eventId]/videos/AccessDeniedPage.tsx
+++ b/src/app/[eventId]/videos/AccessDeniedPage.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { LockOutlined, ArrowLeftOutlined } from "@ant-design/icons";
+import { Button, Typography, Card } from "antd";
+import Link from "next/link";
+
+const { Title, Paragraph } = Typography;
+
+interface AccessDeniedPageProps {
+	eventTitle: string;
+}
+
+export function AccessDeniedPage({ eventTitle }: AccessDeniedPageProps) {
+	return (
+		<div className="max-w-2xl mx-auto text-center">
+			<div className="flex items-center justify-start mb-8">
+				<Link href="/">
+					<Button 
+						type="text" 
+						icon={<ArrowLeftOutlined />} 
+						size="large"
+						className="hover:bg-gray-100"
+					>
+						トップページへ戻る
+					</Button>
+				</Link>
+			</div>
+
+			<Card className="p-8 shadow-lg">
+				<div className="text-center">
+					<div className="text-6xl text-gray-400 mb-4">
+						<LockOutlined />
+					</div>
+					
+					<Title level={2} className="!mb-4">
+						アクセス制限
+					</Title>
+					
+					<Paragraph className="text-lg text-gray-600 mb-6">
+						<strong>{eventTitle}</strong>は現在進行中のイベントのため、投稿動画一覧を公開していません。
+					</Paragraph>
+					
+					<div className="bg-blue-50 p-4 rounded-lg mb-6">
+						<Paragraph className="text-blue-800 mb-2">
+							<strong>動画一覧の公開について</strong>
+						</Paragraph>
+						<Paragraph className="text-blue-700 mb-0">
+							イベントが終了した後に、投稿された動画の一覧を公開いたします。
+						</Paragraph>
+					</div>
+
+					<div className="space-y-4">
+						<Link href="/">
+							<Button type="primary" size="large">
+								トップページへ戻る
+							</Button>
+						</Link>
+					</div>
+				</div>
+			</Card>
+		</div>
+	);
+}

--- a/src/app/[eventId]/videos/VideoList.tsx
+++ b/src/app/[eventId]/videos/VideoList.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { getSubmissions } from "@/lib/firebase/submissions";
+import type { Submission } from "@/types/submission";
+import { YoutubeOutlined, ArrowLeftOutlined } from "@ant-design/icons";
+import "@ant-design/v5-patch-for-react-19";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+import {
+	Button,
+	Space,
+	Table,
+	Tag,
+	Typography,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+
+import { getTwitterIconUrl } from "@/utils/twitter";
+
+const { Title } = Typography;
+
+interface VideoListProps {
+	eventId: string;
+	eventTitle: string;
+}
+
+export function VideoList({ eventId, eventTitle }: VideoListProps) {
+	const [submissions, setSubmissions] = useState<Submission[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchSubmissions = async () => {
+			try {
+				const allSubmissions = await getSubmissions();
+				// イベントIDに基づいてフィルタリング
+				// stageからイベントIDを判定する（例：as-ex-8 → as）
+				const eventSubmissions = allSubmissions.filter((submission) => {
+					const stagePrefix = submission.stage.split("-")[0];
+					return stagePrefix === eventId;
+				});
+				setSubmissions(eventSubmissions);
+			} catch (error) {
+				console.error("Error getting submissions:", error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchSubmissions();
+	}, [eventId]);
+
+	const columns: ColumnsType<Submission> = [
+		{
+			title: "No",
+			key: "index",
+			width: 60,
+			render: (_text, _record, index) => index + 1,
+		},
+		{
+			title: "X",
+			dataIndex: "twitterHandle",
+			key: "twitterHandle",
+			render: (handle: string | undefined) =>
+				handle ? (
+					<a
+						href={`https://twitter.com/${handle.replace("@", "")}`}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="hover:opacity-80"
+					>
+						<Space direction="vertical" align="center">
+							<img
+								src={getTwitterIconUrl(handle)}
+								alt={`${handle}のTwitterアイコン`}
+								className="w-12 h-12 rounded-full"
+							/>
+							<span className="text-sm">{handle}</span>
+						</Space>
+					</a>
+				) : (
+					"-"
+				),
+			width: 120,
+		},
+		{
+			title: "ドクター歴",
+			dataIndex: "doctorHistory",
+			key: "doctorHistory",
+			render: (value: string) => {
+				const mapping: Record<string, string> = {
+					"less-than-6months": "6ヶ月未満",
+					"6months-1year": "6ヶ月〜1年",
+					"1-2years": "1年〜2年",
+					"2-3years": "2年〜3年",
+					"more-than-3years": "3年以上",
+				};
+				return mapping[value] || value;
+			},
+			width: 120,
+		},
+		{
+			title: "ステージ",
+			dataIndex: "stage",
+			key: "stage",
+			filters:
+				submissions.length > 0
+					? Array.from(new Set(submissions.map((s) => s.stage))).map(
+							(stage) => ({
+								text: stage,
+								value: stage,
+							}),
+						)
+					: [],
+			onFilter: (value, record) => record.stage === value,
+			filterSearch: true,
+			width: 100,
+		},
+		{
+			title: "難易度",
+			dataIndex: "difficulty",
+			key: "difficulty",
+			render: (value: string) => (
+				<Tag color={value === "normal" ? "blue" : "red"}>
+					{value === "normal" ? "通常" : "強襲作戦"}
+				</Tag>
+			),
+			width: 100,
+		},
+		{
+			title: "コンセプト",
+			dataIndex: "concept",
+			key: "concept",
+			render: (text: string) => (
+				<div className="max-h-32 overflow-y-auto whitespace-pre-wrap">
+					{text}
+				</div>
+			),
+			width: 300,
+		},
+		{
+			title: "編集",
+			dataIndex: "hasEditing",
+			key: "hasEditing",
+			render: (value: string) => (value === "edited" ? "編集あり" : "編集なし"),
+			width: 100,
+		},
+		{
+			title: "YouTube",
+			dataIndex: "youtubeUrl",
+			key: "youtubeUrl",
+			render: (url: string) => (
+				<a
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-[#FF0000] hover:text-[#FF0000] hover:opacity-80 text-2xl"
+				>
+					<YoutubeOutlined />
+				</a>
+			),
+			width: 80,
+			align: "center",
+		},
+		{
+			title: "応募日時",
+			dataIndex: "createdAt",
+			key: "createdAt",
+			render: (date: Date) => date.toLocaleString(),
+			sorter: (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+			defaultSortOrder: "descend",
+			width: 160,
+		},
+	];
+
+	return (
+		<div className="max-w-7xl mx-auto">
+			<div className="flex items-center justify-between mb-8">
+				<div className="flex items-center gap-4">
+					<Link href="/">
+						<Button 
+							type="text" 
+							icon={<ArrowLeftOutlined />} 
+							size="large"
+							className="hover:bg-gray-100"
+						>
+							トップページへ戻る
+						</Button>
+					</Link>
+					<div>
+						<Title level={2} className="!mb-0">
+							{eventTitle}
+						</Title>
+						<p className="text-gray-600 mt-1">投稿動画一覧</p>
+					</div>
+				</div>
+				<Tag color="blue" className="text-lg px-4 py-1">
+					投稿件数: {submissions.length}件
+				</Tag>
+			</div>
+			
+			<div className="bg-white rounded-lg shadow">
+				<Table
+					columns={columns}
+					dataSource={submissions}
+					loading={loading}
+					rowKey="id"
+					expandable={{
+						expandedRowRender: (record) => (
+							<div className="p-4 bg-gray-50 rounded">
+								<h4 className="font-medium mb-2">自己紹介・備考</h4>
+								<p className="whitespace-pre-wrap text-gray-700">
+									{record.introduction || "なし"}
+								</p>
+							</div>
+						),
+						rowExpandable: (record) => Boolean(record.introduction),
+					}}
+					pagination={{
+						showSizeChanger: true,
+						showTotal: (total) => `全${total}件`,
+						defaultPageSize: 10,
+						pageSizeOptions: ["10", "20", "50", "100"],
+					}}
+					scroll={{ x: 1000 }}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/app/[eventId]/videos/page.tsx
+++ b/src/app/[eventId]/videos/page.tsx
@@ -1,0 +1,80 @@
+import { notFound } from "next/navigation";
+import eventsConfig from "../../../../config/events.json";
+import { VideoList } from "./VideoList";
+import { AccessDeniedPage } from "./AccessDeniedPage";
+
+interface EventConfig {
+	id: string;
+	title: string;
+	deadline: string | null;
+	thumbnailUrl: string;
+	stages: Array<{ value: string; label: string }>;
+	defaultStage: string;
+	active: boolean;
+	calculator?: {
+		title: string;
+		fiveStarOperatorImages: string[];
+	} | null;
+}
+
+interface Params {
+	eventId: string;
+}
+
+// 締切日をパースして比較用の値を返す関数
+function parseDeadline(deadline: string | null): number {
+	if (!deadline) return 0;
+	
+	const match = deadline.match(/(\d+)\/(\d+)/);
+	if (!match) return 0;
+	
+	const month = parseInt(match[1], 10);
+	const day = parseInt(match[2], 10);
+	
+	return month * 100 + day;
+}
+
+// 現在日付を取得して比較用の値を返す関数
+function getCurrentDate(): number {
+	const now = new Date();
+	const month = now.getMonth() + 1;
+	const day = now.getDate();
+	return month * 100 + day;
+}
+
+// 締切日が現在日付より後かどうかを判定する関数
+function isEventActive(deadline: string | null): boolean {
+	if (!deadline) return false;
+	const currentDate = getCurrentDate();
+	const deadlineDate = parseDeadline(deadline);
+	return deadlineDate >= currentDate;
+}
+
+export default async function VideosPage({ params }: { params: Params }) {
+	const { eventId } = params;
+	const events = eventsConfig as Record<string, EventConfig>;
+	const event = events[eventId];
+
+	if (!event) {
+		notFound();
+	}
+
+	// 現在進行中のイベントの場合はアクセス拒否
+	if (isEventActive(event.deadline)) {
+		return (
+			<main className="min-h-screen bg-gray-50">
+				<div className="container mx-auto px-4 py-8">
+					<AccessDeniedPage eventTitle={event.title} />
+				</div>
+			</main>
+		);
+	}
+
+	return (
+		<main className="min-h-screen bg-gray-50">
+			<div className="container mx-auto px-4 py-8">
+				<VideoList eventId={eventId} eventTitle={event.title} />
+			</div>
+		</main>
+	);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,9 +104,9 @@ function EventCard({ event, isPast = false }: { event: Event; isPast?: boolean }
 			}
 			actions={[
 				<div key="apply" className="mx-4">
-					<Link href={event.path}>
+					<Link href={isPast ? `${event.path}/videos` : event.path}>
 						<Button type={isPast ? "default" : "primary"} block>
-							{isPast ? "詳細を見る" : "応募ページへ"}
+							{isPast ? "動画一覧を見る" : "応募ページへ"}
 						</Button>
 					</Link>
 				</div>,


### PR DESCRIPTION
## 概要
過去のイベント専用の動画一覧ページを新規作成し、現在進行中のイベントへのアクセス制御機能を実装しました。

## 主な変更内容

### 1. 過去のイベント用の動画一覧ページを新規作成
- **`src/app/[eventId]/videos/page.tsx`** - 動画一覧ページのルート
- **`src/app/[eventId]/videos/VideoList.tsx`** - 動画一覧表示コンポーネント（管理画面のデザインを参考）
- **`src/app/[eventId]/videos/AccessDeniedPage.tsx`** - アクセス拒否ページ

### 2. アクセス制御機能の実装
- 現在日付と締切日を比較してイベントの状態を判定
- **現在進行中のイベント**: アクセス拒否ページを表示
- **過去のイベント**: 投稿動画一覧を表示

### 3. トップページの変更
- 過去のイベントのボタンテキストを「動画一覧を見る」に変更
- 過去のイベントのリンク先を `/[eventId]/videos` に変更

## 機能詳細

### 動画一覧ページ
- 管理画面と同様のテーブルデザイン
- フィルタリング機能（ステージ別）
- ソート機能（応募日時）
- ページネーション機能
- 展開可能な自己紹介・備考欄
- トップページへの戻るボタン

### アクセス制御
- 現在進行中のイベントの場合は分かりやすいアクセス拒否メッセージ
- 動画一覧公開時期についての説明
- トップページへの戻るボタン

## 動作確認
- [x] 現在進行中のイベント（7/31、8/7）にアクセス時はアクセス拒否ページが表示
- [x] 過去のイベント（6/19以前）にアクセス時は動画一覧が表示
- [x] 動画一覧のフィルタリング・ソート機能が正常に動作
- [x] レスポンシブデザインが適用されている

## セキュリティ
- 現在進行中のイベントの投稿動画は一般公開されない
- 過去のイベントの投稿動画のみが公開される
- 不正アクセスを防止するアクセス制御が実装されている

🤖 Generated with [Claude Code](https://claude.ai/code)