### PR TITLE
feat: 管理画面からイベント設定を管理できるようにする

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "storage.googleapis.com",
+			},
+		],
+	},
 };
 
 export default nextConfig;

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import "@ant-design/v5-patch-for-react-19";
+
+import { formatDeadline } from "@/lib/utils/date";
+import type { ProcessedEvent } from "@/types/events";
+import { CalendarOutlined, UserOutlined } from "@ant-design/icons";
+import { Button, Card, Col, Row, Tag, Typography } from "antd";
+import Image from "next/image";
+import Link from "next/link";
+
+const { Title, Text } = Typography;
+
+function EventCard({
+	event,
+	isPast = false,
+}: { event: ProcessedEvent; isPast?: boolean }) {
+	return (
+		<Card
+			className={`h-full [&_.ant-card-body]:px-4 [&_.ant-card-body]:py-4 transition-shadow hover:shadow-lg cursor-default ${
+				isPast ? "opacity-80" : ""
+			}`}
+			cover={
+				<div className="relative aspect-video bg-gray-100">
+					<Image
+						src={event.thumbnailUrl}
+						alt={event.title}
+						fill
+						className="object-cover"
+						sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
+					/>
+				</div>
+			}
+			actions={[
+				<div key="apply" className="mx-4">
+					<Link href={isPast ? `${event.path}/videos` : event.path}>
+						<Button type={isPast ? "default" : "primary"} block>
+							{isPast ? "動画一覧を見る" : "応募ページへ"}
+						</Button>
+					</Link>
+				</div>,
+			]}
+		>
+			<div className="space-y-2">
+				<div className="text-base font-medium leading-relaxed line-clamp-2 min-h-[3rem]">
+					{event.title}
+				</div>
+				<div className="min-h-[2rem] flex items-center">
+					{event.hasDeadline && (
+						<div className="flex items-center gap-1">
+							<CalendarOutlined
+								className={isPast ? "text-gray-400" : "text-red-500"}
+							/>
+							<Tag color={isPast ? "default" : "red"} className="text-sm">
+								{formatDeadline(event.deadline)}
+							</Tag>
+						</div>
+					)}
+				</div>
+			</div>
+		</Card>
+	);
+}
+
+interface Props {
+	activeEvents: ProcessedEvent[];
+	pastEvents: ProcessedEvent[];
+}
+
+export function HomePageClient({ activeEvents, pastEvents }: Props) {
+	return (
+		<main className="min-h-screen bg-gray-50">
+			{/* 右上のユーザーアイコン */}
+			<div className="fixed top-4 right-4 z-10">
+				<Link href="/my-submissions">
+					<Button
+						type="primary"
+						shape="circle"
+						icon={<UserOutlined />}
+						size="large"
+						title="過去の投稿を編集する"
+					/>
+				</Link>
+			</div>
+
+			<div className="container mx-auto px-4 py-8">
+				<div className="text-center mb-12">
+					<Title level={1} className="!mb-4">
+						アークナイツ攻略動画同時視聴企画
+					</Title>
+					<Text type="secondary" className="text-lg">
+						イベントの投稿企画一覧
+					</Text>
+				</div>
+
+				{/* 現在進行中のイベント */}
+				{activeEvents.length > 0 && (
+					<div className="mb-16">
+						<div className="text-center mb-8">
+							<Title level={2} className="!mb-2">
+								🔥 現在進行中のイベント
+							</Title>
+							<Text type="secondary">現在応募可能なイベントです</Text>
+						</div>
+						<Row gutter={[24, 24]} justify="center">
+							{activeEvents.map((event) => (
+								<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
+									<EventCard event={event} />
+								</Col>
+							))}
+						</Row>
+					</div>
+				)}
+
+				{/* 過去のイベント */}
+				{pastEvents.length > 0 && (
+					<div className="mb-16">
+						<div className="text-center mb-8">
+							<Title level={2} className="!mb-2">
+								📚 過去のイベント
+							</Title>
+							<Text type="secondary">過去に募集したイベントの一覧です</Text>
+						</div>
+						<Row gutter={[24, 24]} justify="center">
+							{pastEvents.map((event) => (
+								<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
+									<EventCard event={event} isPast={true} />
+								</Col>
+							))}
+						</Row>
+					</div>
+				)}
+
+				<div className="text-center mt-12">
+					<Text type="secondary">
+						各イベントの詳細は応募ページをご確認ください
+					</Text>
+				</div>
+			</div>
+		</main>
+	);
+}

--- a/src/app/[eventId]/calculate/page.tsx
+++ b/src/app/[eventId]/calculate/page.tsx
@@ -1,6 +1,5 @@
+import { getEventById } from "@/lib/firebase/events-admin";
 import { notFound } from "next/navigation";
-
-import eventsConfig from "../../../../config/events.json";
 import { ClientCalculatePage } from "./ClientCalculatePage";
 
 interface CalculatePageProps {
@@ -11,7 +10,7 @@ interface CalculatePageProps {
 
 export default async function CalculatePage({ params }: CalculatePageProps) {
 	const { eventId } = await params;
-	const eventConfig = eventsConfig[eventId as keyof typeof eventsConfig];
+	const eventConfig = await getEventById(eventId);
 
 	if (!eventConfig || !eventConfig.active || !eventConfig.calculator) {
 		notFound();

--- a/src/app/[eventId]/page.tsx
+++ b/src/app/[eventId]/page.tsx
@@ -1,9 +1,5 @@
-import { UserOutlined } from "@ant-design/icons";
-import { Button, Typography } from "antd";
-import Link from "next/link";
+import { getEventById } from "@/lib/firebase/events-admin";
 import { notFound } from "next/navigation";
-
-import eventsConfig from "../../../config/events.json";
 import { ClientEventPage } from "./ClientEventPage";
 
 interface EventPageProps {
@@ -14,7 +10,7 @@ interface EventPageProps {
 
 export default async function EventPage({ params }: EventPageProps) {
 	const { eventId } = await params;
-	const eventConfig = eventsConfig[eventId as keyof typeof eventsConfig];
+	const eventConfig = await getEventById(eventId);
 
 	if (!eventConfig || !eventConfig.active) {
 		notFound();

--- a/src/app/[eventId]/videos/page.tsx
+++ b/src/app/[eventId]/videos/page.tsx
@@ -1,7 +1,6 @@
+import { getEventById } from "@/lib/firebase/events-admin";
 import { isEventActive } from "@/lib/utils/date";
-import type { EventsConfig } from "@/types/events";
 import { notFound } from "next/navigation";
-import eventsConfig from "../../../../config/events.json";
 import { AccessDeniedPage } from "./AccessDeniedPage";
 import { VideoList } from "./VideoList";
 
@@ -11,8 +10,7 @@ interface Props {
 
 export default async function VideosPage({ params }: Props) {
 	const { eventId } = await params;
-	const events = eventsConfig as EventsConfig;
-	const event = events[eventId];
+	const event = await getEventById(eventId);
 
 	if (!event) {
 		notFound();

--- a/src/app/admin/AdminNav.tsx
+++ b/src/app/admin/AdminNav.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import "@ant-design/v5-patch-for-react-19";
+
+import { Menu } from "antd";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export function AdminNav() {
+	const pathname = usePathname();
+	const selectedKey = pathname.startsWith("/admin/events") ? "/admin/events" : "/admin";
+
+	const items = [
+		{
+			key: "/admin",
+			label: <Link href="/admin">応募一覧</Link>,
+		},
+		{
+			key: "/admin/events",
+			label: <Link href="/admin/events">イベント管理</Link>,
+		},
+	];
+
+	return (
+		<Menu
+			mode="horizontal"
+			selectedKeys={[selectedKey]}
+			items={items}
+			className="border-b border-gray-200 px-4"
+		/>
+	);
+}

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import "@ant-design/v5-patch-for-react-19";
+
+import type { EventConfig, EventStage } from "@/types/events";
+import {
+	DeleteOutlined,
+	EditOutlined,
+	ImportOutlined,
+	MinusCircleOutlined,
+	PlusOutlined,
+	UploadOutlined,
+} from "@ant-design/icons";
+import {
+	App,
+	Button,
+	DatePicker,
+	Form,
+	Input,
+	Modal,
+	Select,
+	Space,
+	Switch,
+	Table,
+	Tag,
+	Typography,
+	Upload,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import type { UploadFile } from "antd/es/upload";
+import dayjs from "dayjs";
+import Image from "next/image";
+import { useCallback, useEffect, useState } from "react";
+
+const { Title } = Typography;
+
+type EventSource = "firestore" | "static";
+
+interface EventRow extends EventConfig {
+	source: EventSource;
+}
+
+interface EventFormValues {
+	id: string;
+	title: string;
+	deadline?: dayjs.Dayjs;
+	thumbnailUrl?: string;
+	stages: EventStage[];
+	defaultStage: string;
+	active: boolean;
+}
+
+export default function AdminEventsPage() {
+	const { message, modal } = App.useApp();
+	const [events, setEvents] = useState<EventRow[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [modalOpen, setModalOpen] = useState(false);
+	const [editingEvent, setEditingEvent] = useState<EventRow | null>(null);
+	const [form] = Form.useForm<EventFormValues>();
+	const [thumbnailUrl, setThumbnailUrl] = useState<string>("");
+	const [fileList, setFileList] = useState<UploadFile[]>([]);
+	const [uploading, setUploading] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [importing, setImporting] = useState(false);
+
+	const fetchEvents = useCallback(async () => {
+		setLoading(true);
+		try {
+			const [eventsRes, firestoreIdsRes] = await Promise.all([
+				fetch("/api/admin/events"),
+				fetch("/api/admin/events?source=firestore-ids"),
+			]);
+
+			if (!eventsRes.ok) throw new Error("イベント一覧の取得に失敗しました");
+
+			const data: EventConfig[] = await eventsRes.json();
+			let firestoreIds = new Set<string>();
+			if (firestoreIdsRes.ok) {
+				const ids: string[] = await firestoreIdsRes.json();
+				firestoreIds = new Set(ids);
+			}
+
+			const rows: EventRow[] = data.map((e) => ({
+				...e,
+				source: firestoreIds.has(e.id) ? "firestore" : "static",
+			}));
+			setEvents(rows);
+		} catch (err) {
+			message.error(err instanceof Error ? err.message : "読み込みに失敗しました");
+		} finally {
+			setLoading(false);
+		}
+	}, [message]);
+
+	useEffect(() => {
+		fetchEvents();
+	}, [fetchEvents]);
+
+	const openCreateModal = () => {
+		setEditingEvent(null);
+		setThumbnailUrl("");
+		setFileList([]);
+		form.resetFields();
+		form.setFieldsValue({ active: true, stages: [{ value: "", label: "" }] });
+		setModalOpen(true);
+	};
+
+	const openEditModal = (event: EventRow) => {
+		setEditingEvent(event);
+		setThumbnailUrl(event.thumbnailUrl);
+		setFileList([]);
+		form.setFieldsValue({
+			id: event.id,
+			title: event.title,
+			deadline: event.deadline ? dayjs(event.deadline) : undefined,
+			stages: event.stages,
+			defaultStage: event.defaultStage,
+			active: event.active,
+		});
+		setModalOpen(true);
+	};
+
+	const handleUpload = async (file: File): Promise<string> => {
+		const formData = new FormData();
+		formData.append("file", file);
+		const res = await fetch("/api/admin/events/upload", {
+			method: "POST",
+			body: formData,
+		});
+		if (!res.ok) throw new Error("アップロードに失敗しました");
+		const { url } = await res.json();
+		return url as string;
+	};
+
+	const handleSubmit = async () => {
+		try {
+			const values = await form.validateFields();
+			setSubmitting(true);
+
+			const payload: EventConfig = {
+				id: values.id,
+				title: values.title,
+				deadline: values.deadline ? values.deadline.format("YYYY-MM-DD") : null,
+				thumbnailUrl: thumbnailUrl,
+				stages: values.stages,
+				defaultStage: values.defaultStage,
+				active: values.active,
+				calculator: editingEvent?.calculator ?? null,
+			};
+
+			if (editingEvent) {
+				const res = await fetch(`/api/admin/events/${editingEvent.id}`, {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(payload),
+				});
+				if (!res.ok) throw new Error("更新に失敗しました");
+				message.success("イベントを更新しました");
+			} else {
+				const res = await fetch("/api/admin/events", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(payload),
+				});
+				if (!res.ok) {
+					const body = await res.json();
+					throw new Error(body.error ?? "作成に失敗しました");
+				}
+				message.success("イベントを作成しました");
+			}
+
+			setModalOpen(false);
+			fetchEvents();
+		} catch (err) {
+			if (err instanceof Error) message.error(err.message);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const handleDelete = async (event: EventRow) => {
+		const confirmed = await modal.confirm({
+			title: "イベントの削除",
+			content: `「${event.title}」を削除してもよろしいですか？`,
+			okText: "削除",
+			okType: "danger",
+			cancelText: "キャンセル",
+		});
+		if (!confirmed) return;
+
+		try {
+			const res = await fetch(`/api/admin/events/${event.id}`, { method: "DELETE" });
+			if (!res.ok) throw new Error("削除に失敗しました");
+			message.success("イベントを削除しました");
+			fetchEvents();
+		} catch (err) {
+			message.error(err instanceof Error ? err.message : "削除に失敗しました");
+		}
+	};
+
+	const handleImport = async () => {
+		const confirmed = await modal.confirm({
+			title: "JSONからインポート",
+			content: "events.json の全イベントを Firestore にインポートします（既存は上書き）。続けますか？",
+			okText: "インポート",
+			cancelText: "キャンセル",
+		});
+		if (!confirmed) return;
+
+		setImporting(true);
+		try {
+			const res = await fetch("/api/admin/events/import", { method: "POST" });
+			if (!res.ok) throw new Error("インポートに失敗しました");
+			const { count } = await res.json();
+			message.success(`${count} 件のイベントをインポートしました`);
+			fetchEvents();
+		} catch (err) {
+			message.error(err instanceof Error ? err.message : "インポートに失敗しました");
+		} finally {
+			setImporting(false);
+		}
+	};
+
+	// stages の変更を監視してデフォルトステージ選択肢を更新
+	const stages: EventStage[] = Form.useWatch("stages", form) ?? [];
+	const stageOptions = stages
+		.filter((s) => s?.value)
+		.map((s) => ({ value: s.value, label: s.label || s.value }));
+
+	const columns: ColumnsType<EventRow> = [
+		{
+			title: "ID",
+			dataIndex: "id",
+			key: "id",
+			width: 110,
+			render: (id: string) => <code>{id}</code>,
+		},
+		{
+			title: "タイトル",
+			dataIndex: "title",
+			key: "title",
+		},
+		{
+			title: "締切",
+			dataIndex: "deadline",
+			key: "deadline",
+			width: 130,
+			render: (v: string | null) => v ?? "-",
+		},
+		{
+			title: "ソース",
+			dataIndex: "source",
+			key: "source",
+			width: 110,
+			render: (src: EventSource) =>
+				src === "firestore" ? (
+					<Tag color="blue">Firestore</Tag>
+				) : (
+					<Tag color="default">静的設定</Tag>
+				),
+		},
+		{
+			title: "公開",
+			dataIndex: "active",
+			key: "active",
+			width: 80,
+			render: (active: boolean) =>
+				active ? <Tag color="green">公開</Tag> : <Tag color="red">非公開</Tag>,
+		},
+		{
+			title: "操作",
+			key: "action",
+			width: 170,
+			render: (_: unknown, record: EventRow) => {
+				if (record.source === "static") {
+					return <Tag color="default">読み取り専用</Tag>;
+				}
+				return (
+					<Space>
+						<Button
+							type="text"
+							icon={<EditOutlined />}
+							onClick={() => openEditModal(record)}
+						>
+							編集
+						</Button>
+						<Button
+							type="text"
+							danger
+							icon={<DeleteOutlined />}
+							onClick={() => handleDelete(record)}
+						>
+							削除
+						</Button>
+					</Space>
+				);
+			},
+		},
+	];
+
+	return (
+		<main className="min-h-screen p-8">
+			<div className="max-w-5xl mx-auto">
+				<div className="flex justify-between items-center mb-8">
+					<Title level={2} className="!mb-0">
+						イベント管理
+					</Title>
+					<Space>
+						<Button
+							icon={<ImportOutlined />}
+							onClick={handleImport}
+							loading={importing}
+						>
+							JSONからインポート
+						</Button>
+						<Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+							新規イベント作成
+						</Button>
+					</Space>
+				</div>
+
+				<Table
+					columns={columns}
+					dataSource={events}
+					rowKey="id"
+					loading={loading}
+					pagination={false}
+				/>
+
+				<Modal
+					title={editingEvent ? "イベントを編集" : "新規イベント作成"}
+					open={modalOpen}
+					onCancel={() => setModalOpen(false)}
+					onOk={handleSubmit}
+					okText={editingEvent ? "更新" : "作成"}
+					cancelText="キャンセル"
+					confirmLoading={submitting}
+					width={640}
+				>
+					<Form form={form} layout="vertical" className="mt-4">
+						<Form.Item
+							label="ID"
+							name="id"
+							rules={[
+								{ required: true, message: "IDを入力してください" },
+								{
+									pattern: /^[a-z0-9-]+$/,
+									message: "英小文字・数字・ハイフンのみ使用できます",
+								},
+							]}
+						>
+							<Input placeholder="例: at-ex" disabled={!!editingEvent} />
+						</Form.Item>
+
+						<Form.Item
+							label="タイトル"
+							name="title"
+							rules={[{ required: true, message: "タイトルを入力してください" }]}
+						>
+							<Input placeholder="例: イベント『墟』EX攻略動画募集" />
+						</Form.Item>
+
+						<Form.Item label="締切日（任意）" name="deadline">
+							<DatePicker className="w-full" placeholder="例: 2026-06-01" />
+						</Form.Item>
+
+						<Form.Item label="サムネイル画像">
+							{thumbnailUrl && (
+								<div className="mb-2 relative w-40 h-24">
+									<Image
+										src={thumbnailUrl}
+										alt="サムネイルプレビュー"
+										fill
+										className="object-cover rounded"
+									/>
+								</div>
+							)}
+							<Upload
+								fileList={fileList}
+								customRequest={async ({ file, onSuccess, onError }) => {
+									setUploading(true);
+									try {
+										const url = await handleUpload(file as File);
+										setThumbnailUrl(url);
+										onSuccess?.(url);
+										message.success("画像をアップロードしました");
+									} catch (err) {
+										onError?.(err as Error);
+										message.error("画像のアップロードに失敗しました");
+									} finally {
+										setUploading(false);
+									}
+								}}
+								onChange={({ fileList: newList }) => setFileList(newList)}
+								accept="image/*"
+								maxCount={1}
+								showUploadList={false}
+							>
+								<Button icon={<UploadOutlined />} loading={uploading}>
+									画像を選択してアップロード
+								</Button>
+							</Upload>
+						</Form.Item>
+
+						<Form.Item label="ステージ">
+							<Form.List
+								name="stages"
+								rules={[
+									{
+										validator: async (_, stageList) => {
+											if (!stageList || stageList.length === 0) {
+												return Promise.reject(new Error("ステージは1つ以上必要です"));
+											}
+										},
+									},
+								]}
+							>
+								{(fields, { add, remove }, { errors }) => (
+									<>
+										{fields.map(({ key, name }) => (
+											<Space key={key} className="flex mb-2" align="baseline">
+												<Form.Item
+													name={[name, "value"]}
+													rules={[{ required: true, message: "値を入力してください" }]}
+													noStyle
+												>
+													<Input placeholder="値 (例: at-ex-8)" />
+												</Form.Item>
+												<Form.Item
+													name={[name, "label"]}
+													rules={[{ required: true, message: "ラベルを入力してください" }]}
+													noStyle
+												>
+													<Input placeholder="ラベル (例: AT-EX-8)" />
+												</Form.Item>
+												{fields.length > 1 && (
+													<MinusCircleOutlined
+														onClick={() => remove(name)}
+														className="text-red-500 cursor-pointer"
+													/>
+												)}
+											</Space>
+										))}
+										<Form.ErrorList errors={errors} />
+										<Button
+											type="dashed"
+											onClick={() => add({ value: "", label: "" })}
+											icon={<PlusOutlined />}
+											className="mt-2"
+										>
+											ステージを追加
+										</Button>
+									</>
+								)}
+							</Form.List>
+						</Form.Item>
+
+						<Form.Item
+							label="デフォルトステージ"
+							name="defaultStage"
+							rules={[{ required: true, message: "デフォルトステージを選択してください" }]}
+						>
+							<Select placeholder="デフォルトステージを選択" options={stageOptions} />
+						</Form.Item>
+
+						<Form.Item label="公開状態" name="active" valuePropName="checked">
+							<Switch checkedChildren="公開" unCheckedChildren="非公開" />
+						</Form.Item>
+					</Form>
+				</Modal>
+			</div>
+		</main>
+	);
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,3 +1,4 @@
+import { AdminNav } from "./AdminNav";
 import { ConfigProvider } from "antd";
 import jaJP from "antd/locale/ja_JP";
 
@@ -23,6 +24,7 @@ export default function AdminLayout({
 				},
 			}}
 		>
+			<AdminNav />
 			{children}
 		</ConfigProvider>
 	);

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -1,0 +1,71 @@
+/**
+ * 管理者向け単一イベント操作 API
+ * PATCH: イベント更新
+ * DELETE: イベント削除
+ */
+
+import { adminAuth } from "@/lib/firebase/admin";
+import { deleteEvent, updateEvent } from "@/lib/firebase/events-admin";
+import type { EventConfig } from "@/types/events";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+async function verifyAdmin(): Promise<boolean> {
+	const cookieStore = await cookies();
+	const sessionCookie = cookieStore.get("admin_session")?.value;
+	if (!sessionCookie) return false;
+	try {
+		await adminAuth.verifySessionCookie(sessionCookie, true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function PATCH(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const { id } = await params;
+
+	try {
+		const body = (await request.json()) as Partial<EventConfig>;
+		// id は Firestore ドキュメントキーで管理するため除外
+		const { id: _id, ...updateData } = body;
+
+		await updateEvent(id, updateData);
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error("イベント更新エラー:", error);
+		return NextResponse.json(
+			{ error: "イベントの更新に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}
+
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const { id } = await params;
+
+	try {
+		await deleteEvent(id);
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error("イベント削除エラー:", error);
+		return NextResponse.json(
+			{ error: "イベントの削除に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/api/admin/events/import/route.ts
+++ b/src/app/api/admin/events/import/route.ts
@@ -1,0 +1,56 @@
+/**
+ * 管理者向け events.json 一括インポート API
+ * POST: events.json の全イベントを Firestore に書き込む（既存は上書き）
+ */
+
+import { adminAuth } from "@/lib/firebase/admin";
+import { setEvent } from "@/lib/firebase/events-admin";
+import type { EventsConfig } from "@/types/events";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import eventsConfig from "../../../../../../config/events.json";
+
+async function verifyAdmin(): Promise<boolean> {
+	const cookieStore = await cookies();
+	const sessionCookie = cookieStore.get("admin_session")?.value;
+	if (!sessionCookie) return false;
+	try {
+		await adminAuth.verifySessionCookie(sessionCookie, true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function POST() {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	try {
+		const events = eventsConfig as EventsConfig;
+		const entries = Object.entries(events);
+
+		await Promise.all(
+			entries.map(([id, event]) =>
+				setEvent(id, {
+					title: event.title,
+					deadline: event.deadline,
+					thumbnailUrl: event.thumbnailUrl,
+					stages: event.stages,
+					defaultStage: event.defaultStage,
+					active: event.active,
+					calculator: event.calculator ?? null,
+				}),
+			),
+		);
+
+		return NextResponse.json({ success: true, count: entries.length });
+	} catch (error) {
+		console.error("インポートエラー:", error);
+		return NextResponse.json(
+			{ error: "インポートに失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/api/admin/events/route.ts
+++ b/src/app/api/admin/events/route.ts
@@ -1,0 +1,105 @@
+/**
+ * 管理者向けイベント API
+ * GET: 全イベント一覧（Firestore + events.json フォールバック）
+ * POST: 新規イベント作成（Firestore）
+ */
+
+import { adminAuth } from "@/lib/firebase/admin";
+import {
+	getAllEvents,
+	getFirestoreEventIds,
+	setEvent,
+} from "@/lib/firebase/events-admin";
+import type { EventConfig } from "@/types/events";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+async function verifyAdmin(): Promise<boolean> {
+	const cookieStore = await cookies();
+	const sessionCookie = cookieStore.get("admin_session")?.value;
+	if (!sessionCookie) return false;
+	try {
+		await adminAuth.verifySessionCookie(sessionCookie, true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function GET(request: Request) {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const { searchParams } = new URL(request.url);
+
+	// ?source=firestore-ids の場合は Firestore 管理のイベント ID 一覧を返す
+	if (searchParams.get("source") === "firestore-ids") {
+		try {
+			const ids = await getFirestoreEventIds();
+			return NextResponse.json(Array.from(ids));
+		} catch (error) {
+			console.error("FirestoreイベントID取得エラー:", error);
+			return NextResponse.json(
+				{ error: "FirestoreイベントIDの取得に失敗しました" },
+				{ status: 500 },
+			);
+		}
+	}
+
+	try {
+		const events = await getAllEvents(true);
+		return NextResponse.json(events);
+	} catch (error) {
+		console.error("イベント一覧取得エラー:", error);
+		return NextResponse.json(
+			{ error: "イベント一覧の取得に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}
+
+export async function POST(request: Request) {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	try {
+		const body = (await request.json()) as EventConfig;
+		const { id, title, deadline, thumbnailUrl, stages, defaultStage, active, calculator } = body;
+
+		if (!id || !/^[a-z0-9-]+$/.test(id)) {
+			return NextResponse.json(
+				{ error: "IDは英小文字・数字・ハイフンのみ使用できます" },
+				{ status: 400 },
+			);
+		}
+		if (!title) {
+			return NextResponse.json({ error: "タイトルは必須です" }, { status: 400 });
+		}
+		if (!stages || stages.length === 0) {
+			return NextResponse.json(
+				{ error: "ステージは1つ以上必要です" },
+				{ status: 400 },
+			);
+		}
+
+		await setEvent(id, {
+			title,
+			deadline: deadline ?? null,
+			thumbnailUrl: thumbnailUrl ?? "",
+			stages,
+			defaultStage: defaultStage ?? stages[0].value,
+			active: active ?? false,
+			calculator: calculator ?? null,
+		});
+
+		return NextResponse.json({ success: true, id });
+	} catch (error) {
+		console.error("イベント作成エラー:", error);
+		return NextResponse.json(
+			{ error: "イベントの作成に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/api/admin/events/upload/route.ts
+++ b/src/app/api/admin/events/upload/route.ts
@@ -1,0 +1,59 @@
+/**
+ * 管理者向けイベントサムネイル画像アップロード API
+ * POST: Firebase Storage に画像をアップロードし、公開 URL を返す
+ */
+
+import { adminAuth, adminStorage } from "@/lib/firebase/admin";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+async function verifyAdmin(): Promise<boolean> {
+	const cookieStore = await cookies();
+	const sessionCookie = cookieStore.get("admin_session")?.value;
+	if (!sessionCookie) return false;
+	try {
+		await adminAuth.verifySessionCookie(sessionCookie, true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function POST(request: Request) {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	try {
+		const formData = await request.formData();
+		const file = formData.get("file") as File | null;
+
+		if (!file) {
+			return NextResponse.json(
+				{ error: "ファイルが選択されていません" },
+				{ status: 400 },
+			);
+		}
+
+		const buffer = Buffer.from(await file.arrayBuffer());
+		const ext = file.name.split(".").pop() ?? "jpg";
+		const path = `events/thumbnails/${Date.now()}.${ext}`;
+
+		const bucket = adminStorage.bucket(process.env.FIREBASE_STORAGE_BUCKET);
+		const fileRef = bucket.file(path);
+
+		await fileRef.save(buffer, {
+			metadata: { contentType: file.type || "image/jpeg" },
+		});
+		await fileRef.makePublic();
+
+		const url = fileRef.publicUrl();
+		return NextResponse.json({ url });
+	} catch (error) {
+		console.error("画像アップロードエラー:", error);
+		return NextResponse.json(
+			{ error: "画像のアップロードに失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,20 @@
+/**
+ * 公開イベント API
+ * GET: アクティブなイベント一覧（認証不要）
+ */
+
+import { getAllEvents } from "@/lib/firebase/events-admin";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+	try {
+		const events = await getAllEvents(false);
+		return NextResponse.json(events);
+	} catch (error) {
+		console.error("公開イベント一覧取得エラー:", error);
+		return NextResponse.json(
+			{ error: "イベント一覧の取得に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,140 +1,25 @@
-"use client";
-
-import "@ant-design/v5-patch-for-react-19";
-
-import { useEvents } from "@/hooks/useEventData";
-import { formatDeadline } from "@/lib/utils/date";
+import { getAllEvents } from "@/lib/firebase/events-admin";
+import { isEventActive } from "@/lib/utils/date";
 import type { ProcessedEvent } from "@/types/events";
-import { CalendarOutlined, UserOutlined } from "@ant-design/icons";
-import { Button, Card, Col, Row, Tag, Typography } from "antd";
-import Image from "next/image";
-import Link from "next/link";
+import { HomePageClient } from "./HomePageClient";
 
-const { Title, Text } = Typography;
+export default async function HomePage() {
+	const events = await getAllEvents(true);
 
-// イベントカードを表示するコンポーネント
-function EventCard({
-	event,
-	isPast = false,
-}: { event: ProcessedEvent; isPast?: boolean }) {
-	return (
-		<Card
-			className={`h-full [&_.ant-card-body]:px-4 [&_.ant-card-body]:py-4 transition-shadow hover:shadow-lg cursor-default ${
-				isPast ? "opacity-80" : ""
-			}`}
-			cover={
-				<div className="relative aspect-video bg-gray-100">
-					<Image
-						src={event.thumbnailUrl}
-						alt={event.title}
-						fill
-						className="object-cover"
-						sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
-					/>
-				</div>
-			}
-			actions={[
-				<div key="apply" className="mx-4">
-					<Link href={isPast ? `${event.path}/videos` : event.path}>
-						<Button type={isPast ? "default" : "primary"} block>
-							{isPast ? "動画一覧を見る" : "応募ページへ"}
-						</Button>
-					</Link>
-				</div>,
-			]}
-		>
-			<div className="space-y-2">
-				<div className="text-base font-medium leading-relaxed line-clamp-2 min-h-[3rem]">
-					{event.title}
-				</div>
-				<div className="min-h-[2rem] flex items-center">
-					{event.hasDeadline && (
-						<div className="flex items-center gap-1">
-							<CalendarOutlined
-								className={isPast ? "text-gray-400" : "text-red-500"}
-							/>
-							<Tag color={isPast ? "default" : "red"} className="text-sm">
-								{formatDeadline(event.deadline)}
-							</Tag>
-						</div>
-					)}
-				</div>
-			</div>
-		</Card>
-	);
-}
+	const processedEvents: ProcessedEvent[] = events.map((event) => ({
+		...event,
+		path: `/${event.id}`,
+		hasDeadline: Boolean(event.deadline),
+		isActive: isEventActive(event.deadline),
+	}));
 
-export default function HomePage() {
-	const { active: activeEvents, past: pastEvents } = useEvents();
-	return (
-		<main className="min-h-screen bg-gray-50">
-			{/* 右上のユーザーアイコン */}
-			<div className="fixed top-4 right-4 z-10">
-				<Link href="/my-submissions">
-					<Button
-						type="primary"
-						shape="circle"
-						icon={<UserOutlined />}
-						size="large"
-						title="過去の投稿を編集する"
-					/>
-				</Link>
-			</div>
+	const activeEvents = processedEvents
+		.filter((e) => e.isActive)
+		.sort((a, b) => (b.deadline ?? "").localeCompare(a.deadline ?? ""));
 
-			<div className="container mx-auto px-4 py-8">
-				<div className="text-center mb-12">
-					<Title level={1} className="!mb-4">
-						アークナイツ攻略動画同時視聴企画
-					</Title>
-					<Text type="secondary" className="text-lg">
-						イベントの投稿企画一覧
-					</Text>
-				</div>
+	const pastEvents = processedEvents
+		.filter((e) => !e.isActive)
+		.sort((a, b) => (b.deadline ?? "").localeCompare(a.deadline ?? ""));
 
-				{/* 現在進行中のイベント */}
-				{activeEvents.length > 0 && (
-					<div className="mb-16">
-						<div className="text-center mb-8">
-							<Title level={2} className="!mb-2">
-								🔥 現在進行中のイベント
-							</Title>
-							<Text type="secondary">現在応募可能なイベントです</Text>
-						</div>
-						<Row gutter={[24, 24]} justify="center">
-							{activeEvents.map((event) => (
-								<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
-									<EventCard event={event} />
-								</Col>
-							))}
-						</Row>
-					</div>
-				)}
-
-				{/* 過去のイベント */}
-				{pastEvents.length > 0 && (
-					<div className="mb-16">
-						<div className="text-center mb-8">
-							<Title level={2} className="!mb-2">
-								📚 過去のイベント
-							</Title>
-							<Text type="secondary">過去に募集したイベントの一覧です</Text>
-						</div>
-						<Row gutter={[24, 24]} justify="center">
-							{pastEvents.map((event) => (
-								<Col key={event.path} xs={24} sm={12} lg={8} xl={6}>
-									<EventCard event={event} isPast={true} />
-								</Col>
-							))}
-						</Row>
-					</div>
-				)}
-
-				<div className="text-center mt-12">
-					<Text type="secondary">
-						各イベントの詳細は応募ページをご確認ください
-					</Text>
-				</div>
-			</div>
-		</main>
-	);
+	return <HomePageClient activeEvents={activeEvents} pastEvents={pastEvents} />;
 }

--- a/src/hooks/useEventData.ts
+++ b/src/hooks/useEventData.ts
@@ -1,80 +1,88 @@
+/**
+ * イベントデータを管理するカスタムフック
+ * /api/events エンドポイントから動的に取得する
+ */
+
 import { isEventActive } from "@/lib/utils/date";
 import type {
 	CategorizedEvents,
 	EventConfig,
-	EventsConfig,
 	ProcessedEvent,
 } from "@/types/events";
-/**
- * イベントデータを管理するカスタムフック
- */
-import { useMemo } from "react";
-import eventsConfig from "../../config/events.json";
+import { useEffect, useMemo, useState } from "react";
 
-/**
- * 単一のイベントデータを取得するフック
- * @param eventId - イベントID
- * @returns 処理済みイベントデータ、存在しない場合はnull
- */
-export function useEvent(eventId: string): ProcessedEvent | null {
-	return useMemo(() => {
-		const events = eventsConfig as EventsConfig;
-		const event = events[eventId];
-
-		if (!event) return null;
-
-		return processEvent(event);
-	}, [eventId]);
-}
-
-/**
- * すべてのイベントデータを取得し、アクティブ/過去で分類するフック
- * @returns カテゴリ別に分類されたイベントデータ
- */
-export function useEvents(): CategorizedEvents {
-	return useMemo(() => {
-		const events = eventsConfig as EventsConfig;
-		const allEvents = Object.values(events)
-			.map(processEvent)
-			.sort((a, b) => (b.deadline ?? "").localeCompare(a.deadline ?? ""));
-
-		return {
-			active: allEvents.filter((event) => event.isActive),
-			past: allEvents.filter((event) => !event.isActive),
-		};
-	}, []);
-}
-
-/**
- * 特定の条件でフィルタリングされたイベントを取得するフック
- * @param filter - フィルター関数
- * @returns フィルタリングされたイベント配列
- */
-export function useFilteredEvents(
-	filter: (event: ProcessedEvent) => boolean,
-): ProcessedEvent[] {
-	return useMemo(() => {
-		const events = eventsConfig as EventsConfig;
-		return Object.values(events)
-			.filter((event) => event.active)
-			.map(processEvent)
-			.filter(filter)
-			.sort((a, b) => (b.deadline ?? "").localeCompare(a.deadline ?? ""));
-	}, [filter]);
-}
-
-/**
- * イベント設定から処理済みイベントデータを作成
- * @param event - 元のイベント設定
- * @returns 処理済みイベントデータ
- */
 function processEvent(event: EventConfig): ProcessedEvent {
-	const isActive = isEventActive(event.deadline);
-
 	return {
 		...event,
 		path: `/${event.id}`,
 		hasDeadline: Boolean(event.deadline),
-		isActive,
+		isActive: isEventActive(event.deadline),
 	};
+}
+
+function useAllEvents(): { events: EventConfig[]; loading: boolean } {
+	const [events, setEvents] = useState<EventConfig[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		fetch("/api/events")
+			.then((r) => r.json())
+			.then((data: EventConfig[]) => setEvents(data))
+			.catch(console.error)
+			.finally(() => setLoading(false));
+	}, []);
+
+	return { events, loading };
+}
+
+/**
+ * 単一のイベントデータを取得するフック
+ */
+export function useEvent(eventId: string): {
+	event: ProcessedEvent | null;
+	loading: boolean;
+} {
+	const { events, loading } = useAllEvents();
+	const event = useMemo(() => {
+		const found = events.find((e) => e.id === eventId);
+		return found ? processEvent(found) : null;
+	}, [events, eventId]);
+	return { event, loading };
+}
+
+/**
+ * すべてのイベントをアクティブ/過去で分類するフック
+ */
+export function useEvents(): CategorizedEvents & { loading: boolean } {
+	const { events, loading } = useAllEvents();
+
+	const categorized = useMemo(() => {
+		const processed = events
+			.map(processEvent)
+			.sort((a, b) => (b.deadline ?? "").localeCompare(a.deadline ?? ""));
+		return {
+			active: processed.filter((e) => e.isActive),
+			past: processed.filter((e) => !e.isActive),
+		};
+	}, [events]);
+
+	return { ...categorized, loading };
+}
+
+/**
+ * フィルター関数でイベントを絞り込むフック
+ */
+export function useFilteredEvents(
+	filter: (event: ProcessedEvent) => boolean,
+): { events: ProcessedEvent[]; loading: boolean } {
+	const { events: rawEvents, loading } = useAllEvents();
+
+	const events = useMemo(() => {
+		return rawEvents
+			.map(processEvent)
+			.filter(filter)
+			.sort((a, b) => (b.deadline ?? "").localeCompare(a.deadline ?? ""));
+	}, [rawEvents, filter]);
+
+	return { events, loading };
 }

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -1,6 +1,7 @@
 import { cert, getApps, initializeApp } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
+import { getStorage } from "firebase-admin/storage";
 
 const app =
 	getApps().length === 0
@@ -18,3 +19,4 @@ const app =
 
 export const adminAuth = getAuth(app);
 export const adminDb = getFirestore(app);
+export const adminStorage = getStorage(app);

--- a/src/lib/firebase/events-admin.ts
+++ b/src/lib/firebase/events-admin.ts
@@ -1,0 +1,82 @@
+/**
+ * Firestore イベント CRUD + events.json フォールバック（サーバーサイド専用）
+ */
+
+import eventsConfig from "../../../config/events.json";
+import type { EventConfig, EventsConfig } from "@/types/events";
+import { adminDb } from "./admin";
+
+function toEventConfig(id: string, data: FirebaseFirestore.DocumentData): EventConfig {
+	return {
+		id,
+		title: data.title ?? "",
+		deadline: data.deadline ?? null,
+		thumbnailUrl: data.thumbnailUrl ?? "",
+		stages: data.stages ?? [],
+		defaultStage: data.defaultStage ?? "",
+		active: data.active ?? false,
+		calculator: data.calculator ?? null,
+	};
+}
+
+/**
+ * Firestore に存在するイベント ID のセットを返す
+ */
+export async function getFirestoreEventIds(): Promise<Set<string>> {
+	const snapshot = await adminDb.collection("events").get();
+	return new Set(snapshot.docs.map((doc) => doc.id));
+}
+
+/**
+ * 全イベントを取得（Firestore 優先、存在しないものは events.json で補完）
+ * @param includeInactive - 非アクティブなイベントも含める場合 true
+ */
+export async function getAllEvents(includeInactive = false): Promise<EventConfig[]> {
+	const snapshot = await adminDb.collection("events").get();
+	const firestoreEvents = snapshot.docs.map((doc) =>
+		toEventConfig(doc.id, doc.data()),
+	);
+	const firestoreIds = new Set(firestoreEvents.map((e) => e.id));
+
+	// events.json のうち Firestore にないものをフォールバックとして追加
+	const jsonFallback = Object.values(eventsConfig as EventsConfig).filter(
+		(e) => !firestoreIds.has(e.id),
+	);
+
+	const all = [...firestoreEvents, ...jsonFallback];
+	return includeInactive ? all : all.filter((e) => e.active);
+}
+
+/**
+ * 単一イベントを取得（Firestore → events.json の順で検索）
+ */
+export async function getEventById(eventId: string): Promise<EventConfig | null> {
+	const doc = await adminDb.collection("events").doc(eventId).get();
+	if (doc.exists) {
+		return toEventConfig(doc.id, doc.data()!);
+	}
+
+	const json = eventsConfig as EventsConfig;
+	return json[eventId] ?? null;
+}
+
+/**
+ * イベントを Firestore に作成または上書き保存
+ */
+export async function setEvent(id: string, data: Omit<EventConfig, "id">): Promise<void> {
+	await adminDb.collection("events").doc(id).set(data);
+}
+
+/**
+ * Firestore のイベントを部分更新
+ */
+export async function updateEvent(id: string, data: Partial<Omit<EventConfig, "id">>): Promise<void> {
+	await adminDb.collection("events").doc(id).update(data);
+}
+
+/**
+ * Firestore からイベントを削除
+ */
+export async function deleteEvent(id: string): Promise<void> {
+	await adminDb.collection("events").doc(id).delete();
+}


### PR DESCRIPTION
## Summary

- `/admin/events` ページを新設し、イベントの作成・編集・削除・画像アップロードが管理画面から可能に
- Firestore `events` コレクションでイベントを管理。`events.json` はフォールバック（読み取り専用）として維持
- 「JSONからインポート」ボタンで既存 `events.json` → Firestore への一括移行が可能
- サムネイル画像を Firebase Storage にアップロードし、管理画面でプレビュー表示

## 変更詳細

### 新規 API ルート
| メソッド | パス | 説明 |
|---|---|---|
| GET | `/api/events` | 公開イベント一覧（認証不要） |
| GET/POST | `/api/admin/events` | 管理者向けイベント一覧・作成 |
| PATCH/DELETE | `/api/admin/events/[id]` | イベント更新・削除 |
| POST | `/api/admin/events/upload` | 画像アップロード → Firebase Storage |
| POST | `/api/admin/events/import` | `events.json` 一括 Firestore インポート |

### アーキテクチャ変更
- ホームページをサーバーコンポーネント化（Firestore から直接取得 → `HomePageClient.tsx` に表示ロジック分離）
- `[eventId]` / `[eventId]/videos` / `[eventId]/calculate` サーバーページを Firestore 対応に更新
- `useEventData` フックを `/api/events` fetch ベースに移行（`loading` 状態を追加）
- 管理画面に `AdminNav` ナビゲーションを追加

## Test plan

- [ ] `/admin/events` にアクセスし「JSONからインポート」を実行 → events.json の全イベントが Firestore に登録されること
- [ ] インポート後、一覧に「Firestore」バッジが表示されること
- [ ] 新規作成・編集・削除が動作すること（Firestoreのみ編集可能、静的設定は「読み取り専用」）
- [ ] サムネイル画像をアップロードしプレビューが表示されること
- [ ] トップページ・`/[eventId]`・`/[eventId]/videos` が正常に動作すること
- [ ] `next.config.ts` に `storage.googleapis.com` を追加済みのため Firebase Storage 画像が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)