### PR TITLE
fix: ログインページではナビゲーションタブを非表示にする

### DIFF
--- a/src/app/admin/AdminNav.tsx
+++ b/src/app/admin/AdminNav.tsx
@@ -8,6 +8,10 @@ import { usePathname } from "next/navigation";
 
 export function AdminNav() {
 	const pathname = usePathname();
+
+	// ログインページではナビゲーションを表示しない
+	if (pathname === "/admin/login") return null;
+
 	const selectedKey = pathname.startsWith("/admin/events") ? "/admin/events" : "/admin";
 
 	const items = [


### PR DESCRIPTION
## Summary

- `/admin/login` ページでは `AdminNav`（応募一覧・イベント管理タブ）を表示しないよう修正
- ログイン成功後は `/admin` にリダイレクト（`login/page.tsx` の既存実装）

## 動作

| 状態 | ナビゲーション |
|---|---|
| `/admin/login`（ログイン前） | 非表示 |
| `/admin`（ログイン済み） | 表示 |
| `/admin/events`（ログイン済み） | 表示 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)