### PR TITLE
feat: サムネイル画像を Firebase Storage に一括移行する機能を追加

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -4,6 +4,7 @@ import "@ant-design/v5-patch-for-react-19";
 
 import type { EventConfig, EventStage } from "@/types/events";
 import {
+	CloudUploadOutlined,
 	DeleteOutlined,
 	EditOutlined,
 	MinusCircleOutlined,
@@ -53,6 +54,7 @@ export default function AdminEventsPage() {
 	const [fileList, setFileList] = useState<UploadFile[]>([]);
 	const [uploading, setUploading] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
+	const [migrating, setMigrating] = useState(false);
 
 	const fetchEvents = useCallback(async () => {
 		setLoading(true);
@@ -154,6 +156,33 @@ export default function AdminEventsPage() {
 		}
 	};
 
+	const handleMigrateImages = async () => {
+		const confirmed = await modal.confirm({
+			title: "画像を Firebase Storage に移行",
+			content: "ローカルパスのサムネイル画像をすべて Firebase Storage にアップロードし、Firestore の URL を更新します。続けますか？",
+			okText: "移行する",
+			cancelText: "キャンセル",
+		});
+		if (!confirmed) return;
+
+		setMigrating(true);
+		try {
+			const res = await fetch("/api/admin/events/migrate-images", { method: "POST" });
+			if (!res.ok) throw new Error("移行に失敗しました");
+			const { migrated, errors } = await res.json();
+			if (errors > 0) {
+				message.warning(`${migrated} 件移行完了、${errors} 件エラー`);
+			} else {
+				message.success(`${migrated} 件の画像を移行しました`);
+			}
+			fetchEvents();
+		} catch (err) {
+			message.error(err instanceof Error ? err.message : "移行に失敗しました");
+		} finally {
+			setMigrating(false);
+		}
+	};
+
 	const handleDelete = async (event: EventConfig) => {
 		const confirmed = await modal.confirm({
 			title: "イベントの削除",
@@ -240,6 +269,13 @@ export default function AdminEventsPage() {
 					<Title level={2} className="!mb-0">
 						イベント管理
 					</Title>
+					<Button
+						icon={<CloudUploadOutlined />}
+						onClick={handleMigrateImages}
+						loading={migrating}
+					>
+						画像をStorageに移行
+					</Button>
 					<Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
 						新規イベント作成
 					</Button>

--- a/src/app/api/admin/events/migrate-images/route.ts
+++ b/src/app/api/admin/events/migrate-images/route.ts
@@ -1,0 +1,77 @@
+/**
+ * 管理者向け画像移行 API
+ * POST: /public/events/ の画像を Firebase Storage に移行し Firestore の URL を更新する
+ */
+
+import { adminAuth, adminStorage } from "@/lib/firebase/admin";
+import { getAllEvents, updateEvent } from "@/lib/firebase/events-admin";
+import { cookies } from "next/headers";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+
+async function verifyAdmin(): Promise<boolean> {
+	const cookieStore = await cookies();
+	const sessionCookie = cookieStore.get("admin_session")?.value;
+	if (!sessionCookie) return false;
+	try {
+		await adminAuth.verifySessionCookie(sessionCookie, true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function mimeType(filePath: string): string {
+	const ext = filePath.split(".").pop()?.toLowerCase();
+	if (ext === "png") return "image/png";
+	if (ext === "gif") return "image/gif";
+	if (ext === "webp") return "image/webp";
+	return "image/jpeg";
+}
+
+export async function POST() {
+	if (!(await verifyAdmin())) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const events = await getAllEvents(true);
+	const bucket = adminStorage.bucket(process.env.FIREBASE_STORAGE_BUCKET);
+	const publicDir = path.join(process.cwd(), "public");
+
+	const results: { id: string; status: "migrated" | "skipped" | "error"; url?: string; reason?: string }[] = [];
+
+	for (const event of events) {
+		// ローカルパス（/events/... または /img/...）のみ対象
+		if (!event.thumbnailUrl.startsWith("/")) {
+			results.push({ id: event.id, status: "skipped", reason: "すでに外部 URL" });
+			continue;
+		}
+
+		const localPath = path.join(publicDir, event.thumbnailUrl);
+		const storagePath = `events/thumbnails/${event.id}${path.extname(event.thumbnailUrl)}`;
+
+		try {
+			const buffer = await readFile(localPath);
+			const fileRef = bucket.file(storagePath);
+
+			await fileRef.save(buffer, {
+				metadata: { contentType: mimeType(event.thumbnailUrl) },
+			});
+			await fileRef.makePublic();
+
+			const url = fileRef.publicUrl();
+			await updateEvent(event.id, { thumbnailUrl: url });
+
+			results.push({ id: event.id, status: "migrated", url });
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : "不明なエラー";
+			results.push({ id: event.id, status: "error", reason });
+		}
+	}
+
+	const migrated = results.filter((r) => r.status === "migrated").length;
+	const errors = results.filter((r) => r.status === "error").length;
+
+	return NextResponse.json({ migrated, errors, results });
+}


### PR DESCRIPTION
## Summary

管理画面の「画像をStorageに移行」ボタン1クリックで、`/public/events/` の全サムネイルを Firebase Storage に自動移行します。

## 仕組み

1. Firestore の全イベントを走査
2. `thumbnailUrl` がローカルパス（`/events/...` で始まる）のイベントを対象に選択
3. サーバー側のファイルシステム（`public/`）から画像を読み込み
4. Firebase Storage にアップロード → 公開設定
5. Firestore の `thumbnailUrl` を Storage の公開 URL に更新

## 移行後

- `/public/events/` の静的ファイルは不要になるため削除可能
- ボタンは「すでに外部 URL」のイベントをスキップするので何度押しても安全

## Test plan

- [ ] `/admin/events` で「画像をStorageに移行」ボタンを押す
- [ ] 成功メッセージ（例: 「9 件の画像を移行しました」）が表示されること
- [ ] Firebase Storage コンソールで `events/thumbnails/` にファイルが存在すること
- [ ] トップページのサムネイルが引き続き表示されること（URL が Storage に変わる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)