### PR TITLE
fix: Firebase auth/popup-blocked（Chrome 115+ クロスオリジン制限）を修正する

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+const firebaseProjectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+
 const nextConfig: NextConfig = {
 	images: {
 		remotePatterns: [
@@ -8,6 +10,18 @@ const nextConfig: NextConfig = {
 				hostname: "storage.googleapis.com",
 			},
 		],
+	},
+	async rewrites() {
+		// Chrome 115+ のサードパーティストレージ制限を回避するため、
+		// Firebase Auth ハンドラーを同一オリジンとして透過プロキシする。
+		// authDomain をアプリの実ドメインに変更することで有効になる。
+		// 参考: https://firebase.google.com/docs/auth/web/redirect-best-practices
+		return [
+			{
+				source: "/__/auth/:path*",
+				destination: `https://${firebaseProjectId}.firebaseapp.com/__/auth/:path*`,
+			},
+		];
 	},
 };
 

--- a/src/app/admin/google-login.tsx
+++ b/src/app/admin/google-login.tsx
@@ -46,8 +46,6 @@ export const GoogleLoginForm = ({ error }: Props) => {
 			}
 		} catch (popupError: unknown) {
 			const code = (popupError as { code?: string }).code ?? "";
-			// TODO: デバッグ確認後に削除する
-			console.error("popup error code:", code, popupError);
 
 			if (code === "auth/popup-blocked") {
 				setLocalError(


### PR DESCRIPTION
## 概要

Chrome 115+ のサードパーティストレージ分離ポリシーにより、`signInWithPopup` が本番環境（Vercel）でのみ `auth/popup-blocked` を発生させる問題を修正します。

### 原因

アプリは `*.vercel.app` で動作しているのに Firebase の `authDomain` が `*.firebaseapp.com` という別ドメインを指しているため、ブラウザがクロスオリジンのストレージアクセスをブロックします。

### 修正内容

- `next.config.ts` に `/__/auth/*` → `https://<project>.firebaseapp.com/__/auth/*` の透過プロキシを追加
- `google-login.tsx` のデバッグ用 `console.error` を削除

## デプロイ後に必要な作業（Vercel 環境変数の変更）

このコードだけでは**まだ動きません**。Vercel で以下の追加作業が必要です。

### 1. Vercel 環境変数の変更

`NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` の値を Firebase のデフォルトドメインからアプリの実ドメインに変更する：

| 変更前 | 変更後 |
|--------|--------|
| `<project-id>.firebaseapp.com` | `arknights-event.vercel.app`（または実際のVercel URL） |

変更後に**再デプロイが必要**です（`NEXT_PUBLIC_` 変数はビルド時に埋め込まれるため）。

### 2. Firebase Console でドメインを認証済みに追加

Firebase Console → Authentication → Settings → 承認済みドメイン → `arknights-event.vercel.app` を追加

## テスト計画

- [ ] Vercel の本番環境でGoogleログインボタンをクリックし、ポップアップが開くことを確認
- [ ] Google アカウントを選択後、`/admin` にリダイレクトされることを確認
- [ ] ローカル環境（localhost）でも引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)