### PR TITLE
fix: signInWithPopup → signInWithRedirect に切り替えてポップアップブロックを回避する

### DIFF
--- a/src/app/admin/google-login.tsx
+++ b/src/app/admin/google-login.tsx
@@ -4,7 +4,7 @@ import "@ant-design/v5-patch-for-react-19";
 import { clientAuth } from "@/lib/firebase/client";
 import { GoogleOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
-import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { GoogleAuthProvider, signInWithRedirect } from "firebase/auth";
 import { useState } from "react";
 
 interface Props {
@@ -20,42 +20,11 @@ export const GoogleLoginForm = ({ error }: Props) => {
 		setLocalError(null);
 		const provider = new GoogleAuthProvider();
 		try {
-			const result = await signInWithPopup(clientAuth, provider);
-
-			// 匿名ユーザーは拒否（Firebase設定が誤っている場合の安全ガード）
-			if (result.user.isAnonymous) {
-				setLocalError(
-					"Firebase の設定が正しくありません。管理者に連絡してください。",
-				);
-				setLoading(false);
-				return;
-			}
-
-			const idToken = await result.user.getIdToken();
-			const res = await fetch("/api/admin/auth", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ idToken }),
-			});
-			if (res.ok) {
-				window.location.href = "/admin";
-			} else {
-				const data = await res.json();
-				setLocalError(data.error ?? "ログインに失敗しました");
-				setLoading(false);
-			}
-		} catch (popupError: unknown) {
-			const code = (popupError as { code?: string }).code ?? "";
-
-			if (code === "auth/popup-blocked") {
-				setLocalError(
-					`ポップアップがブロックされました（${code}）。アドレスバーのアイコンをクリックして、このサイトのポップアップを許可してください。`,
-				);
-			} else if (code === "auth/popup-closed-by-user") {
-				// ユーザーがキャンセルした場合はエラー表示しない
-			} else {
-				setLocalError(`ログインに失敗しました（${code}）`);
-			}
+			await signInWithRedirect(clientAuth, provider);
+			// ページ遷移するためここより後は実行されない
+		} catch (redirectError: unknown) {
+			const code = (redirectError as { code?: string }).code ?? "";
+			setLocalError(`ログインに失敗しました（${code}）`);
 			setLoading(false);
 		}
 	};
@@ -68,9 +37,7 @@ export const GoogleLoginForm = ({ error }: Props) => {
 				<h2 className="text-center text-2xl font-bold text-gray-900">
 					管理者ページ
 				</h2>
-				{displayError && (
-					<Alert type="error" message={displayError} showIcon />
-				)}
+				{displayError && <Alert type="error" message={displayError} showIcon />}
 				<Button
 					type="primary"
 					icon={<GoogleOutlined />}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import "@ant-design/v5-patch-for-react-19";
+import { clientAuth } from "@/lib/firebase/client";
+import { getRedirectResult } from "firebase/auth";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { GoogleLoginForm } from "../google-login";
@@ -12,11 +14,53 @@ export default function LoginPage() {
 	// Strict Mode の二重実行を防ぐフラグ
 	const initialized = useRef(false);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: 初回マウント時のみ実行する意図的な設計
 	useEffect(() => {
 		if (initialized.current) return;
 		initialized.current = true;
 
-		const checkExistingSession = async () => {
+		const init = async () => {
+			// signInWithRedirect で Google から戻ってきた場合の結果を取得
+			try {
+				const result = await getRedirectResult(clientAuth);
+				if (result) {
+					// 匿名ユーザーは拒否（Firebase設定が誤っている場合の安全ガード）
+					if (result.user.isAnonymous) {
+						setAuthError(
+							"Firebase の設定が正しくありません。管理者に連絡してください。",
+						);
+						setIsChecking(false);
+						return;
+					}
+
+					const idToken = await result.user.getIdToken();
+					const res = await fetch("/api/admin/auth", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ idToken }),
+					});
+
+					if (res.ok) {
+						router.push("/admin");
+						return;
+					}
+
+					const data = await res.json();
+					setAuthError(data.error ?? "ログインに失敗しました");
+					setIsChecking(false);
+					return;
+				}
+			} catch (error: unknown) {
+				const code = (error as { code?: string }).code ?? "";
+				// ユーザーがキャンセルした場合はエラー表示しない
+				if (code !== "auth/redirect-cancelled-by-user") {
+					setAuthError(`ログインに失敗しました（${code}）`);
+				}
+				setIsChecking(false);
+				return;
+			}
+
+			// リダイレクト結果なし → 既存セッションを確認
 			try {
 				const res = await fetch("/api/admin/auth/check");
 				if (res.ok) {
@@ -27,8 +71,7 @@ export default function LoginPage() {
 			setIsChecking(false);
 		};
 
-		checkExistingSession();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		init();
 	}, []);
 
 	if (isChecking) {


### PR DESCRIPTION
## 概要

`auth/popup-blocked` エラーを根本的に解消するため、Firebase のログイン方式をポップアップからページ遷移（リダイレクト）に切り替えます。

## 変更内容

- **`google-login.tsx`**: `signInWithPopup` → `signInWithRedirect` に変更。`window.open()` を使わないためポップアップブロッカーの影響を受けない
- **`login/page.tsx`**: ページロード時に `getRedirectResult` を呼び出し、Google からのリダイレクト後に認証結果を処理してセッションを発行する

## ログインフロー（変更後）

```
1. ユーザーが「Googleでログイン」をクリック
2. signInWithRedirect → ページが Google OAuth へ遷移（ポップアップなし）
3. Google 認証完了 → /__/auth/handler に戻る（next.config.ts のプロキシ経由）
4. /admin/login に戻る → getRedirectResult で結果を取得
5. ID トークンを POST /api/admin/auth へ送信 → セッションクッキー発行
6. /admin にリダイレクト
```

## テスト計画

- [ ] Googleでログインボタンをクリックすると Google の選択画面に遷移することを確認
- [ ] Google アカウントを選択後、`/admin` にリダイレクトされることを確認
- [ ] ローカル環境（localhost）でも動作することを確認
- [ ] キャンセル時（ブラウザバックなど）にエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)