### PR TITLE
fix: デバッグ用のエラーコード表示を削除する

### DIFF
--- a/src/app/admin/google-login.tsx
+++ b/src/app/admin/google-login.tsx
@@ -22,9 +22,8 @@ export const GoogleLoginForm = ({ error }: Props) => {
 		try {
 			await signInWithRedirect(clientAuth, provider);
 			// ページ遷移するためここより後は実行されない
-		} catch (redirectError: unknown) {
-			const code = (redirectError as { code?: string }).code ?? "";
-			setLocalError(`ログインに失敗しました（${code}）`);
+		} catch {
+			setLocalError("ログインに失敗しました");
 			setLoading(false);
 		}
 	};

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -51,10 +51,10 @@ export default function LoginPage() {
 					return;
 				}
 			} catch (error: unknown) {
-				const code = (error as { code?: string }).code ?? "";
+				const code = (error as { code?: string }).code;
 				// ユーザーがキャンセルした場合はエラー表示しない
 				if (code !== "auth/redirect-cancelled-by-user") {
-					setAuthError(`ログインに失敗しました（${code}）`);
+					setAuthError("ログインに失敗しました");
 				}
 				setIsChecking(false);
 				return;


### PR DESCRIPTION
## 概要

ログイン試行錯誤中に追加したデバッグ用のエラーコード表示（`（auth/popup-blocked）` のような表示）を削除し、ユーザー向けの汎用メッセージに統一します。

## 変更内容

- `google-login.tsx`: エラーメッセージから `（${code}）` を削除、不要な catch 変数を削除
- `login/page.tsx`: エラーメッセージから `（${code}）` を削除（`auth/redirect-cancelled-by-user` の判定は維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)